### PR TITLE
Add a single-argument constructor

### DIFF
--- a/src/IndexedDims.jl
+++ b/src/IndexedDims.jl
@@ -20,6 +20,8 @@ end
 Base.parent(arr::IndexedDimsArray) = arr.data
 Base.size(arr::IndexedDimsArray) = size(parent(arr))
 
+IndexedDimsArray(data::AbstractArray) = IndexedDimsArray(data, axes(data)...)
+
 function IndexedDimsArray(data::AbstractArray{T, N}, dim_inds::Vararg{AcceleratedVector, N}) where {T, N}
     return IndexedDimsArray(data, dim_inds)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,12 @@ using Test
 @testset "IndexedDims.jl" begin
     a = IndexedDimsArray([1 2 3; 4 5 6; 7 8 9], 2:4, 2:4)
 
+    # constructor
+    @test ==(
+        IndexedDimsArray([1 2; 3 4; 5 6]),
+        IndexedDimsArray([1 2; 3 4; 5 6], Base.OneTo(2), Base.OneTo(3))
+    )
+
     # standard fallback
     @test a[1] == 1
     @test a[3, 2] == 8


### PR DESCRIPTION
Allows you construct with `IndexedDimsArray(x)`

Mostly just feels right to me for wrapper-array-types to have single-argument constructors available 🤷‍♂ 