### PR TITLE
Solving Int vs other indexing problem (DO NOT MERGE)

### DIFF
--- a/src/IndexedDims.jl
+++ b/src/IndexedDims.jl
@@ -1,6 +1,7 @@
 module IndexedDims
 
 using AcceleratedArrays
+import Base: to_index, tail
 
 export IndexedDimsArray, bypass
 
@@ -12,38 +13,7 @@ end
 
 bypass(val::T) where {T} = BypassIndex{T}(val)
 
-struct IndexedDimsArray{T, N, A<:AbstractArray{T, N}, Is<:Tuple{Vararg{<:AcceleratedVector,N}}} <: AbstractArray{T, N}
-    data::A
-    indexes::Is
-end
-
-Base.parent(arr::IndexedDimsArray) = arr.data
-Base.size(arr::IndexedDimsArray) = size(parent(arr))
-
-IndexedDimsArray(data::AbstractArray) = IndexedDimsArray(data, axes(data)...)
-
-function IndexedDimsArray(data::AbstractArray{T, N}, dim_inds::Vararg{AcceleratedVector, N}) where {T, N}
-    return IndexedDimsArray(data, dim_inds)
-end
-
-function IndexedDimsArray(data::AbstractArray{T, N}, dim_inds::Vararg{AbstractVector, N}) where {T, N}
-    return IndexedDimsArray(data, map(autoaccelerate, dim_inds))
-end
-
-### simple fallback indexing (might delete later)
-function Base.getindex(arr::IndexedDimsArray{T, N}, inds::Vararg{Int, N}) where {T, N}
-    return Base.getindex(parent(arr), inds...)
-end
-
-function Base.setindex!(arr::IndexedDimsArray{T, N}, val, inds::Vararg{Int, N}) where {T, N}
-    return Base.setindex!(parent(arr), val, inds...)
-end
-###
-
-function Base.similar(arr::IndexedDimsArray{T, N, A}, inds::Tuple{Vararg{AbstractUnitRange, N}}) where {T, N, A}
-    return IndexedDimsArray(similar(parent(arr), inds), map(reindex, arr.indexes, inds))
-end
-
+include("indexeddimsarray.jl")
 include("stdindexing.jl")  # a wrapper for non-value (regular) indexing (hypothetical)
 include("dimindexing.jl")  # value indexing
 

--- a/src/dimindexing.jl
+++ b/src/dimindexing.jl
@@ -25,10 +25,6 @@ function Base.to_indices(arr::IndexedDimsArray,
     (axes(first(inds), 1), to_indices(arr, tail(inds), tail(I))...)
 end
 
-
-
-#Base.to_indices(arr::IndexedDimsArray, inds::Tuple{}, I::Tuple{}) = ()
- 
 function Base.to_indices(arr::IndexedDimsArray, inds::Tuple{AbstractVector}, I::Tuple{Any})
     to_index(first(inds), first(I))
 end
@@ -36,18 +32,6 @@ end
 function Base.to_indices(arr::IndexedDimsArray, inds::Tuple{AbstractVector}, I::Tuple{Colon})
     (axes(first(inds), 1),)
 end
-
-
-
-#function Base.to_indices(arr::IndexedDimsArray, inds::Tuple{AbstractVector}, I::Tuple{Colon})
-#    axes(first(inds), 1)
-#end
-
-
-
-#Base.to_indices(arr::IndexedDimsArray, inds::AbstractVector, I::Any) = to_index(inds, I)
-
-#Base.to_indices(arr::IndexedDimsArray, inds::AbstractVector, I::Colon) = axes(inds, 1)
 
 function Base.getindex(arr::IndexedDimsArray{T, N}, inds::Any) where {T, N}
     getindex(parent(arr), inds)
@@ -61,8 +45,7 @@ function Base.getindex(arr::IndexedDimsArray{T, N}, inds::Vararg{Any, N}) where 
 end
 
 function Base.setindex!(arr::IndexedDimsArray{T, N}, val, inds::Vararg{Any, N}) where {T, N}
-    @boundscheck checkbounds(arr, inds...)
-    @inbounds setindex!(parent(arr), val, to_indices(arr, inds)...)
+    setindex!(parent(arr), val, to_indices(arr, inds)...)
 end
 
 #=

--- a/src/dimindexing.jl
+++ b/src/dimindexing.jl
@@ -6,6 +6,66 @@ unwrap_index(acc::AcceleratedVector, ind) = findall(in(ind), acc)
 unwrap_index(acc::AcceleratedVector, ::Colon) = Colon()
 unwrap_index(acc::AcceleratedVector, ind::BypassIndex) = ind.index
 
+### simple fallback indexing (might delete later)
+#=
+Differes from base in that:
+The terminal call `to_index` isn't using the original array (in this case `arr`)
+   but uses the axis and index (i.e. `to_index(inds, I)`
+
+=#
+function Base.to_indices(arr::IndexedDimsArray,
+                         inds::Tuple{AbstractVector,Vararg{AbstractVector,N}},
+                         I::Tuple{Any,Vararg{Any,N}}) where N
+    (to_index(first(inds), first(I)), to_indices(arr, tail(inds), tail(I))...)
+end
+
+function Base.to_indices(arr::IndexedDimsArray,
+                         inds::Tuple{AbstractVector,Vararg{AbstractVector,N}},
+                         I::Tuple{Colon,Vararg{Any,N}}) where N
+    (axes(first(inds), 1), to_indices(arr, tail(inds), tail(I))...)
+end
+
+
+
+#Base.to_indices(arr::IndexedDimsArray, inds::Tuple{}, I::Tuple{}) = ()
+ 
+function Base.to_indices(arr::IndexedDimsArray, inds::Tuple{AbstractVector}, I::Tuple{Any})
+    to_index(first(inds), first(I))
+end
+
+function Base.to_indices(arr::IndexedDimsArray, inds::Tuple{AbstractVector}, I::Tuple{Colon})
+    (axes(first(inds), 1),)
+end
+
+
+
+#function Base.to_indices(arr::IndexedDimsArray, inds::Tuple{AbstractVector}, I::Tuple{Colon})
+#    axes(first(inds), 1)
+#end
+
+
+
+#Base.to_indices(arr::IndexedDimsArray, inds::AbstractVector, I::Any) = to_index(inds, I)
+
+#Base.to_indices(arr::IndexedDimsArray, inds::AbstractVector, I::Colon) = axes(inds, 1)
+
+function Base.getindex(arr::IndexedDimsArray{T, N}, inds::Any) where {T, N}
+    getindex(parent(arr), inds)
+end
+
+Base.getindex(arr::IndexedDimsArray, inds::Colon) = arr
+
+
+function Base.getindex(arr::IndexedDimsArray{T, N}, inds::Vararg{Any, N}) where {T, N}
+    getindex(parent(arr), to_indices(arr, inds)...)
+end
+
+function Base.setindex!(arr::IndexedDimsArray{T, N}, val, inds::Vararg{Any, N}) where {T, N}
+    @boundscheck checkbounds(arr, inds...)
+    @inbounds setindex!(parent(arr), val, to_indices(arr, inds)...)
+end
+
+#=
 function dim_getindex(arr::IndexedDimsArray{T, N}, inds::Vararg{Any, N}) where {T, N}
     # return Base.getindex(parent(arr), dim_to_indices(arr, inds)...)
     return invoke(getindex, Tuple{AbstractArray, Vararg{Any, N}}, arr, dim_to_indices(arr, inds)...)
@@ -22,3 +82,5 @@ end
 function Base.setindex!(arr::IndexedDimsArray{T, N}, val, inds::Vararg{Any, N}) where {T, N}
     return dim_setindex!(arr, inds...)
 end
+
+=#

--- a/src/indexeddimsarray.jl
+++ b/src/indexeddimsarray.jl
@@ -1,0 +1,45 @@
+struct IndexedDimsArray{T, N, A<:AbstractArray{T, N}, Is<:Tuple{Vararg{<:AbstractVector,N}}} <: AbstractArray{T, N}
+    data::A
+    indexes::Is
+
+    function IndexedDimsArray{T,N,A,Is}(data::A, indexes::Is) where {T,N,A,Is}
+        check_indexeddims_params(data, indexes)
+        new{T,N,A,Is}(data, indexes)
+    end
+end
+
+Base.parent(arr::IndexedDimsArray) = arr.data
+
+Base.size(arr::IndexedDimsArray) = size(parent(arr))
+
+Base.axes(arr::IndexedDimsArray) = arr.indexes
+
+IndexedDimsArray(data::AbstractArray) = IndexedDimsArray(data, axes(data)...)
+
+function IndexedDimsArray(data::AbstractArray{T, N}, dim_inds::Vararg{AcceleratedVector, N}) where {T, N}
+    return IndexedDimsArray(data, dim_inds)
+end
+
+function IndexedDimsArray(data::AbstractArray{T, N}, dim_inds::Vararg{AbstractVector, N}) where {T, N}
+    return IndexedDimsArray(data, map(autoaccelerate, dim_inds))
+end
+
+function IndexedDimsArray(data::AbstractArray{T, N}, dim_inds::Vararg{AbstractRange, N}) where {T, N}
+    return IndexedDimsArray{T,N,typeof(data),typeof(dim_inds)}(data, dim_inds)
+end
+
+###
+
+function Base.similar(arr::IndexedDimsArray{T, N, A}, inds::Tuple{Vararg{AbstractUnitRange, N}}) where {T, N, A}
+    return IndexedDimsArray(similar(parent(arr), inds), map(reindex, arr.indexes, inds))
+end
+
+
+function check_indexeddims_params(data::AbstractArray{T,N}, indexes::Tuple{Vararg{Any,N}}) where {T,N}
+    if size(data) == length.(indexes)
+        return nothing
+    else
+        error("IndexedDimsArray indexes must each be the same length as the parent data's dimensions,
+              got length.(indexes) = $(length.(indexes)) and size(parent) = $(size(parent)).")
+    end
+end


### PR DESCRIPTION
This is a minor rethinking of the current approach.

1. Allow any `AbstractVector` to be an index
1. Only `AcceleratedVector`s are guaranteed to go through reverse indexing even with `Int`.
1. Default behavior is to use `to_index` downstream from `to_indices`.

This solves several problems.

1. We aren't backed into a corner with only allowing `AcceleratedVector`, so anyone can extend the `IndexedDimsArray` type if they implement a custom `AbstractVector`.
2. Because the default is to use `to_index` we also inherit any future optimizations from base that `AcceleratedArrays` might not have.
3. This also allows faster linear indexing if given normal indices and appropariate for the parent type.

Note: I haven't fully worked out bugs yet so don't merge. But I wanted feedback on this approach before going all in with it.